### PR TITLE
fix ggdist

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -728,6 +728,11 @@
       "Source": "Repository",
       "Repository": "CRAN"
     },
+    "ggdist": {
+      "Package": "ggdist",
+      "Version": "3.3.1",
+      "Source": "Repository"
+    },
     "ggplot2": {
       "Package": "ggplot2",
       "Version": "3.4.1",


### PR DESCRIPTION
ggdist, a package that had a new release 2 weeks ago, and is needed but for some reason isn't recorded in the renv lock file. This breaks the module restoration for us.